### PR TITLE
fix: validate DOM nodes before tick updates

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -272,20 +272,22 @@ export default function NetworkGraph() {
         return
       }
 
-      // Verify the first element is still a valid DOM node
-      if (!linkNodes[0] || !linkNodes[0].nodeName) {
+      const isValidDomNode = (el: unknown): el is Element =>
+        !!el && typeof (el as Element).nodeName === "string"
+
+      if (!linkNodes.every(isValidDomNode)) {
         console.log("[v0] Invalid link elements detected, stopping simulation")
         simulation.stop()
         return
       }
 
-      if (!nodeNodes[0] || !nodeNodes[0].nodeName) {
+      if (!nodeNodes.every(isValidDomNode)) {
         console.log("[v0] Invalid node elements detected, stopping simulation")
         simulation.stop()
         return
       }
 
-      if (!labelNodes[0] || !labelNodes[0].nodeName) {
+      if (!labelNodes.every(isValidDomNode)) {
         console.log("[v0] Invalid label elements detected, stopping simulation")
         simulation.stop()
         return


### PR DESCRIPTION
## Summary
- avoid `nodeName.toLowerCase` errors by checking each D3 element is a valid DOM node before updating positions

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f485f7a48330816c794f67579729