### PR TITLE
Use Ctrl+I for group dialog

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -173,8 +173,8 @@ export default function NetworkGraph() {
           event.preventDefault()
           setShowAllGroups(true)
           break
-        case "n":
-        case "N":
+        case "i":
+        case "I":
           if (event.ctrlKey) {
             event.preventDefault()
             event.stopPropagation()


### PR DESCRIPTION
## Summary
- Change group dialog keyboard shortcut to Ctrl+I instead of Ctrl+N

## Testing
- `pnpm lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a203ff45b4833089b6d3203586bae8