### PR TITLE
feat: add local audio layer with storage fallback

### DIFF
--- a/app/gestor/page.tsx
+++ b/app/gestor/page.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { attachAudioLayer } from "@/lib/audio"
+
+export default function GestorPage() {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const instanceRef = useRef<any>(null)
+
+  useEffect(() => {
+    if (!rootRef.current) return
+    const instance = attachAudioLayer({
+      nodesSelection: rootRef.current.querySelectorAll('[data-extid]') as NodeListOf<HTMLElement>,
+      getExtId: (el) => el.dataset.extid || "",
+      rootElement: rootRef.current,
+      options: { allowLocalFileSystem: true }
+    })
+    instanceRef.current = instance
+    return () => instance.dispose()
+  }, [])
+
+  return (
+    <div ref={rootRef} className="p-4 space-y-4">
+      <button
+        onClick={() => instanceRef.current?.requestFolderPermission()}
+        className="px-4 py-2 bg-blue-500 text-white rounded"
+      >
+        Configurar carpeta local
+      </button>
+      <div className="flex gap-4">
+        <div data-extid="n1" className="w-12 h-12 rounded-full bg-gray-300 flex items-center justify-center cursor-pointer">
+          1
+        </div>
+        <div data-extid="n2" className="w-12 h-12 rounded-full bg-gray-300 flex items-center justify-center cursor-pointer">
+          2
+        </div>
+        <div data-extid="n3" className="w-12 h-12 rounded-full bg-gray-300 flex items-center justify-center cursor-pointer">
+          3
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -1,0 +1,191 @@
+import type { Metadata } from './types';
+
+const DB_NAME = 'audio-layer';
+const DB_VERSION = 1;
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains('audios')) {
+        db.createObjectStore('audios');
+      }
+      if (!db.objectStoreNames.contains('metadata')) {
+        db.createObjectStore('metadata');
+      }
+      if (!db.objectStoreNames.contains('handles')) {
+        db.createObjectStore('handles');
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export class FileStore {
+  private systemHandle: FileSystemDirectoryHandle | null = null;
+  private dbPromise = openDB();
+
+  constructor(private options: { allowLocalFileSystem?: boolean } = {}) {}
+
+  async requestFolderPermission() {
+    if (!this.options.allowLocalFileSystem) {
+      throw new Error('FSA disabled');
+    }
+    const root = await (window as any).showDirectoryPicker();
+    const gestor = await root.getDirectoryHandle('gestor', { create: true });
+    const system = await gestor.getDirectoryHandle('system', { create: true });
+    await system.getDirectoryHandle('audios', { create: true });
+    await system.getDirectoryHandle('temp', { create: true });
+    const data = await system.getDirectoryHandle('data', { create: true });
+    try {
+      await data.getFileHandle('metadata.json');
+    } catch {
+      await this.atomicWriteJSON(data, 'metadata.json', {
+        schema_version: 1,
+        nodes: {},
+      });
+    }
+    this.systemHandle = system;
+    const db = await this.dbPromise;
+    const tx = db.transaction('handles', 'readwrite');
+    tx.objectStore('handles').put(system, 'root');
+    await new Promise((res, rej) => {
+      tx.oncomplete = () => res(undefined);
+      tx.onerror = () => rej(tx.error);
+    });
+  }
+
+  private async getAudiosHandle() {
+    if (!this.systemHandle) throw new Error('No system handle');
+    return this.systemHandle.getDirectoryHandle('audios');
+  }
+
+  private async getDataHandle() {
+    if (!this.systemHandle) throw new Error('No system handle');
+    return this.systemHandle.getDirectoryHandle('data');
+  }
+
+  async writeAudio(extId: string, blob: Blob) {
+    const safe = sanitizeExtId(extId) + '.webm';
+    if (this.systemHandle) {
+      const audios = await this.getAudiosHandle();
+      const fh = await audios.getFileHandle(safe, { create: true });
+      const w = await fh.createWritable();
+      await w.write(blob);
+      await w.close();
+    } else {
+      const db = await this.dbPromise;
+      const tx = db.transaction('audios', 'readwrite');
+      tx.objectStore('audios').put({ blob, mime: blob.type }, extId);
+      await new Promise((res, rej) => {
+        tx.oncomplete = () => res(undefined);
+        tx.onerror = () => rej(tx.error);
+      });
+    }
+  }
+
+  async readAudio(extId: string): Promise<Blob | null> {
+    const safe = sanitizeExtId(extId) + '.webm';
+    if (this.systemHandle) {
+      try {
+        const audios = await this.getAudiosHandle();
+        const fh = await audios.getFileHandle(safe);
+        const file = await fh.getFile();
+        return file;
+      } catch {
+        return null;
+      }
+    } else {
+      const db = await this.dbPromise;
+      const tx = db.transaction('audios');
+      const req = tx.objectStore('audios').get(extId);
+      return new Promise((res, rej) => {
+        req.onsuccess = () => {
+          const v = req.result;
+          res(v ? v.blob : null);
+        };
+        req.onerror = () => rej(req.error);
+      });
+    }
+  }
+
+  async deleteAudio(extId: string) {
+    const safe = sanitizeExtId(extId) + '.webm';
+    if (this.systemHandle) {
+      const audios = await this.getAudiosHandle();
+      await audios.removeEntry(safe).catch(() => {});
+    } else {
+      const db = await this.dbPromise;
+      const tx = db.transaction('audios', 'readwrite');
+      tx.objectStore('audios').delete(extId);
+      await new Promise((res, rej) => {
+        tx.oncomplete = () => res(undefined);
+        tx.onerror = () => rej(tx.error);
+      });
+    }
+  }
+
+  async readMeta(): Promise<Metadata> {
+    if (this.systemHandle) {
+      const data = await this.getDataHandle();
+      try {
+        const fh = await data.getFileHandle('metadata.json');
+        const file = await fh.getFile();
+        const text = await file.text();
+        return JSON.parse(text) as Metadata;
+      } catch {
+        return { schema_version: 1, nodes: {} };
+      }
+    } else {
+      const db = await this.dbPromise;
+      const tx = db.transaction('metadata');
+      const req = tx.objectStore('metadata').get('singleton');
+      return new Promise((res, rej) => {
+        req.onsuccess = () => {
+          res(req.result || { schema_version: 1, nodes: {} });
+        };
+        req.onerror = () => rej(req.error);
+      });
+    }
+  }
+
+  async writeMeta(meta: Metadata) {
+    if (this.systemHandle) {
+      const data = await this.getDataHandle();
+      await this.atomicWriteJSON(data, 'metadata.json', meta);
+    } else {
+      const db = await this.dbPromise;
+      const tx = db.transaction('metadata', 'readwrite');
+      tx.objectStore('metadata').put(meta, 'singleton');
+      await new Promise((res, rej) => {
+        tx.oncomplete = () => res(undefined);
+        tx.onerror = () => rej(tx.error);
+      });
+    }
+  }
+
+  private async atomicWriteJSON(dir: FileSystemDirectoryHandle, name: string, data: any) {
+    const tmp = name + '.tmp';
+    const tmpHandle = await dir.getFileHandle(tmp, { create: true });
+    const w = await tmpHandle.createWritable();
+    await w.write(JSON.stringify(data));
+    await w.close();
+    await dir.removeEntry(name).catch(() => {});
+    if ((tmpHandle as any).move) {
+      await (tmpHandle as any).move(name);
+    } else {
+      const final = await dir.getFileHandle(name, { create: true });
+      const wf = await final.createWritable();
+      const file = await tmpHandle.getFile();
+      await wf.write(await file.text());
+      await wf.close();
+      await dir.removeEntry(tmp);
+    }
+  }
+}
+
+function sanitizeExtId(extId: string) {
+  return extId.replace(/[^A-Za-z0-9 .,_-]+/g, '').replace(/\s+/g, ' ').trim();
+}

--- a/lib/audio/gestures.ts
+++ b/lib/audio/gestures.ts
@@ -1,0 +1,30 @@
+export function attachTapLongPress(
+  el: HTMLElement,
+  opts: { onTap: () => void; onLongPress: () => void; longPressMs?: number }
+) {
+  let timer: any;
+  let longPressed = false;
+  const longMs = opts.longPressMs ?? 700;
+
+  const cancel = () => {
+    clearTimeout(timer);
+    timer = null;
+  };
+
+  el.addEventListener('pointerdown', () => {
+    longPressed = false;
+    timer = setTimeout(() => {
+      longPressed = true;
+      opts.onLongPress();
+    }, longMs);
+  });
+
+  el.addEventListener('pointerup', () => {
+    if (!longPressed) {
+      opts.onTap();
+    }
+    cancel();
+  });
+
+  el.addEventListener('pointerleave', cancel);
+}

--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -1,0 +1,171 @@
+import { FileStore } from './fileStore';
+import { Recorder } from './recorder';
+import { Player } from './player';
+import { attachTapLongPress } from './gestures';
+import type { NodeState } from './types';
+
+interface AttachOptions {
+  allowLocalFileSystem?: boolean;
+  autoSaveMetadata?: boolean;
+  longPressMs?: number;
+  onStateChange?: (extId: string, state: NodeState) => void;
+  onError?: (code: string, ctx?: any) => void;
+}
+
+interface AttachArgs {
+  nodesSelection: string | NodeListOf<HTMLElement> | HTMLElement[];
+  getExtId: (el: HTMLElement) => string;
+  rootElement?: Document | HTMLElement;
+  options?: AttachOptions;
+}
+
+export function attachAudioLayer({
+  nodesSelection,
+  getExtId,
+  rootElement = document,
+  options = {},
+}: AttachArgs) {
+  const store = new FileStore({ allowLocalFileSystem: options.allowLocalFileSystem });
+  const recorder = new Recorder();
+  const player = new Player();
+  const states: Map<string, NodeState> = new Map();
+  let recordingExt: string | null = null;
+
+  player.onEnded = extId => {
+    setState(extId, 'has-audio');
+  };
+
+  function setState(extId: string, st: NodeState) {
+    states.set(extId, st);
+    options.onStateChange?.(extId, st);
+  }
+
+  function elements(): HTMLElement[] {
+    if (typeof nodesSelection === 'string') {
+      const scope = rootElement instanceof Document ? rootElement : rootElement.ownerDocument!;
+      return Array.from(scope.querySelectorAll(nodesSelection)) as HTMLElement[];
+    }
+    return Array.from(nodesSelection as any);
+  }
+
+  elements().forEach(el => bind(el));
+
+  function bind(el: HTMLElement) {
+    const extId = getExtId(el);
+    setState(extId, 'idle');
+    attachTapLongPress(
+      el,
+      {
+        longPressMs: options.longPressMs,
+        onTap: () => handleTap(extId),
+        onLongPress: () => handleLong(extId),
+      }
+    );
+  }
+
+  async function handleTap(extId: string) {
+    const st = states.get(extId) || 'idle';
+    try {
+      if (st === 'idle') {
+        await startRecording(extId);
+      } else if (st === 'recording') {
+        await stopRecording(extId);
+      } else if (st === 'has-audio') {
+        await play(extId);
+      } else if (st === 'playing') {
+        pause();
+        setState(extId, 'paused');
+      } else if (st === 'paused') {
+        await play(extId);
+      }
+    } catch (e: any) {
+      options.onError?.('E_BUSY', e);
+    }
+  }
+
+  async function handleLong(extId: string) {
+    await remove(extId);
+  }
+
+  async function startRecording(extId: string) {
+    if (recordingExt) throw new Error('busy');
+    await recorder.start();
+    recordingExt = extId;
+    setState(extId, 'recording');
+  }
+
+  async function stopRecording(extId: string) {
+    if (recordingExt !== extId) return;
+    const { blob, duration } = await recorder.stop();
+    await store.writeAudio(extId, blob);
+    const meta = await store.readMeta();
+    const now = new Date().toISOString();
+    meta.nodes[extId] = {
+      extId,
+      local_path: `audios/${sanitizeExtId(extId)}.webm`,
+      duration_seconds: duration,
+      mime: blob.type,
+      created_at: now,
+      last_modified: now,
+    };
+    await store.writeMeta(meta);
+    recordingExt = null;
+    setState(extId, 'has-audio');
+  }
+
+  async function play(extId: string) {
+    const blob = await store.readAudio(extId);
+    if (!blob) {
+      const meta = await store.readMeta();
+      meta.nodes[extId] = null;
+      await store.writeMeta(meta);
+      setState(extId, 'idle');
+      return;
+    }
+    await player.play(blob, extId);
+    setState(extId, 'playing');
+  }
+
+  function pause() {
+    player.pause();
+  }
+
+  async function remove(extId: string) {
+    pause();
+    await store.deleteAudio(extId);
+    const meta = await store.readMeta();
+    meta.nodes[extId] = null;
+    await store.writeMeta(meta);
+    setState(extId, 'idle');
+  }
+
+  async function download(extId: string) {
+    const blob = await store.readAudio(extId);
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = sanitizeExtId(extId) + '.webm';
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return {
+    requestFolderPermission: () => store.requestFolderPermission(),
+    startRecording,
+    stopRecording,
+    play,
+    pause,
+    delete: remove,
+    download,
+    dispose: () => {
+      elements().forEach(el => {
+        el.replaceWith(el.cloneNode(true));
+      });
+    },
+  };
+}
+
+function sanitizeExtId(extId: string) {
+  return extId.replace(/[^A-Za-z0-9 .,_-]+/g, '').replace(/\s+/g, ' ').trim();
+}

--- a/lib/audio/player.ts
+++ b/lib/audio/player.ts
@@ -1,0 +1,35 @@
+export class Player {
+  private audio = new Audio();
+  private currentUrl: string | null = null;
+  private currentExtId: string | null = null;
+
+  constructor() {
+    this.audio.addEventListener('ended', () => {
+      if (this.currentExtId && this.onEnded) {
+        this.onEnded(this.currentExtId);
+      }
+    });
+  }
+
+  onEnded?: (extId: string) => void;
+
+  async play(src: string | Blob, extId: string) {
+    if (this.currentUrl) {
+      this.audio.pause();
+      URL.revokeObjectURL(this.currentUrl);
+      this.currentUrl = null;
+    }
+    if (src instanceof Blob) {
+      this.currentUrl = URL.createObjectURL(src);
+      this.audio.src = this.currentUrl;
+    } else {
+      this.audio.src = src;
+    }
+    this.currentExtId = extId;
+    await this.audio.play();
+  }
+
+  pause() {
+    this.audio.pause();
+  }
+}

--- a/lib/audio/recorder.ts
+++ b/lib/audio/recorder.ts
@@ -1,0 +1,36 @@
+export class Recorder {
+  private mediaRecorder: MediaRecorder | null = null;
+  private chunks: BlobPart[] = [];
+  private startTime = 0;
+
+  async start() {
+    if (this.mediaRecorder) throw new Error('busy');
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+      ? 'audio/webm;codecs=opus'
+      : undefined;
+    this.mediaRecorder = new MediaRecorder(stream, mime ? { mimeType: mime } : {});
+    this.chunks = [];
+    this.startTime = Date.now();
+    this.mediaRecorder.ondataavailable = e => this.chunks.push(e.data);
+    this.mediaRecorder.start();
+    return this.mediaRecorder.mimeType;
+  }
+
+  stop(): Promise<{ blob: Blob; duration: number }> {
+    return new Promise((resolve, reject) => {
+      if (!this.mediaRecorder) {
+        reject(new Error('not-recording'));
+        return;
+      }
+      const mr = this.mediaRecorder;
+      mr.onstop = () => {
+        const blob = new Blob(this.chunks, { type: mr.mimeType });
+        const duration = (Date.now() - this.startTime) / 1000;
+        this.mediaRecorder = null;
+        resolve({ blob, duration });
+      };
+      mr.stop();
+    });
+  }
+}

--- a/lib/audio/types.ts
+++ b/lib/audio/types.ts
@@ -1,0 +1,21 @@
+export interface NodeMeta {
+  extId: string;
+  local_path: string;
+  duration_seconds: number;
+  mime: string;
+  created_at: string;
+  last_modified: string;
+}
+
+export interface Metadata {
+  schema_version: 1;
+  nodes: Record<string, NodeMeta | null>;
+}
+
+export type NodeState =
+  | 'idle'
+  | 'recording'
+  | 'has-audio'
+  | 'playing'
+  | 'paused'
+  | 'error';


### PR DESCRIPTION
## Summary
- add FileStore with FSA and IndexedDB implementations
- build recorder/player and attachAudioLayer state machine
- add demo page to configure local folder and test node audio

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (incomplete: prompts for ESLint setup)


------
https://chatgpt.com/codex/tasks/task_e_68a24adc9df883308b4e57a30f0e8016