### PR TITLE
feat: request local folder permissions

### DIFF
--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -1,0 +1,208 @@
+import type { MetadataFile } from './types';
+
+/**
+ * Minimal FileStore implementing File System Access API with IndexedDB fallback.
+ * This implementation intentionally keeps logic compact and avoids parallel writes.
+ */
+export class FileStore {
+  private dirHandle: FileSystemDirectoryHandle | null = null;
+  private dbPromise: Promise<IDBDatabase> | null = null;
+  constructor(private options: { allowLocalFileSystem?: boolean; autoSaveMetadata?: boolean } = {}) {}
+
+  async init(): Promise<void> {
+    if (!this.options.allowLocalFileSystem) return;
+    try {
+      const db = await this.openDB();
+      const tx = db.transaction('handles');
+      const req = tx.objectStore('handles').get('dir');
+      await new Promise<void>(resolve => {
+        req.onsuccess = async () => {
+          const handle = req.result as FileSystemDirectoryHandle | undefined;
+          if (handle && (await this.verifyPermission(handle))) {
+            this.dirHandle = handle;
+            await this.setupDirectory();
+          }
+          resolve();
+        };
+        req.onerror = () => resolve();
+      });
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async requestFolderPermission(): Promise<boolean> {
+    if (!this.options.allowLocalFileSystem || !('showDirectoryPicker' in window)) {
+      return false;
+    }
+    try {
+      const handle = await (window as any).showDirectoryPicker();
+      if (!(await this.verifyPermission(handle))) return false;
+      this.dirHandle = handle;
+      await this.setupDirectory();
+      const db = await this.openDB();
+      const tx = db.transaction('handles', 'readwrite');
+      tx.objectStore('handles').put(this.dirHandle, 'dir');
+      await tx.done?.catch(() => {});
+      return true;
+    } catch {
+      this.dirHandle = null;
+      return false;
+    }
+  }
+
+  hasAccess() {
+    return !!this.dirHandle;
+  }
+
+  private async verifyPermission(handle: FileSystemDirectoryHandle): Promise<boolean> {
+    const mode: any = 'readwrite';
+    const perm = await handle.queryPermission?.({ mode });
+    if (perm === 'granted') return true;
+    if (perm === 'prompt') {
+      const res = await handle.requestPermission?.({ mode });
+      return res === 'granted';
+    }
+    return false;
+  }
+
+  private async setupDirectory() {
+    if (!this.dirHandle) return;
+    const system = await this.dirHandle.getDirectoryHandle('gestor', { create: true });
+    await system.getDirectoryHandle('system', { create: true })
+      .then(async sys => {
+        await sys.getDirectoryHandle('audios', { create: true });
+        await sys.getDirectoryHandle('temp', { create: true });
+        const dataDir = await sys.getDirectoryHandle('data', { create: true });
+        try {
+          await dataDir.getFileHandle('metadata.json');
+        } catch {
+          const file = await dataDir.getFileHandle('metadata.json', { create: true });
+          const writable = await file.createWritable();
+          await writable.write(JSON.stringify({ schema_version: 1, nodes: {} }, null, 2));
+          await writable.close();
+        }
+      });
+  }
+
+  private async openDB(): Promise<IDBDatabase> {
+    if (!this.dbPromise) {
+      this.dbPromise = new Promise((resolve, reject) => {
+        const req = indexedDB.open('audio-layer', 2);
+        req.onupgradeneeded = () => {
+          const db = req.result;
+          if (!db.objectStoreNames.contains('audios')) db.createObjectStore('audios');
+          if (!db.objectStoreNames.contains('metadata')) db.createObjectStore('metadata');
+          if (!db.objectStoreNames.contains('handles')) db.createObjectStore('handles');
+        };
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+      });
+    }
+    return this.dbPromise;
+  }
+
+  async writeAudio(extId: string, blob: Blob): Promise<void> {
+    if (this.dirHandle) {
+      const file = await this.getAudioFileHandle(extId, true);
+      const writable = await file.createWritable();
+      await writable.write(blob);
+      await writable.close();
+    } else {
+      const db = await this.openDB();
+      const tx = db.transaction('audios', 'readwrite');
+      tx.objectStore('audios').put({ blob, mime: blob.type }, extId);
+      await tx.done?.catch(() => {});
+    }
+  }
+
+  async readAudio(extId: string): Promise<Blob | null> {
+    if (this.dirHandle) {
+      try {
+        const file = await this.getAudioFileHandle(extId, false);
+        const blob = await file.getFile();
+        return blob;
+      } catch {
+        return null;
+      }
+    } else {
+      const db = await this.openDB();
+      return new Promise((resolve) => {
+        const tx = db.transaction('audios');
+        const req = tx.objectStore('audios').get(extId);
+        req.onsuccess = () => resolve(req.result?.blob || null);
+        req.onerror = () => resolve(null);
+      });
+    }
+  }
+
+  async deleteAudio(extId: string): Promise<void> {
+    if (this.dirHandle) {
+      try {
+        const file = await this.getAudioFileHandle(extId, false);
+        await file.remove?.();
+      } catch {
+        /* ignore */
+      }
+    } else {
+      const db = await this.openDB();
+      const tx = db.transaction('audios', 'readwrite');
+      tx.objectStore('audios').delete(extId);
+      await tx.done?.catch(() => {});
+    }
+  }
+
+  async readMeta(): Promise<MetadataFile> {
+    if (this.dirHandle) {
+      const dataDir = await this.getDataDir();
+      const file = await dataDir.getFileHandle('metadata.json');
+      const text = await (await file.getFile()).text();
+      return JSON.parse(text) as MetadataFile;
+    } else {
+      const db = await this.openDB();
+      return new Promise((resolve) => {
+        const tx = db.transaction('metadata');
+        const req = tx.objectStore('metadata').get('singleton');
+        req.onsuccess = () => resolve(req.result || { schema_version: 1, nodes: {} });
+        req.onerror = () => resolve({ schema_version: 1, nodes: {} });
+      });
+    }
+  }
+
+  async writeMeta(meta: MetadataFile): Promise<void> {
+    if (this.dirHandle) {
+      const dataDir = await this.getDataDir();
+      const tmp = await dataDir.getFileHandle('metadata.tmp.json', { create: true });
+      const writable = await tmp.createWritable();
+      await writable.write(JSON.stringify(meta));
+      await writable.close();
+      await dataDir.removeEntry?.('metadata.json').catch(() => {});
+      await tmp.move?.('metadata.json');
+    } else {
+      const db = await this.openDB();
+      const tx = db.transaction('metadata', 'readwrite');
+      tx.objectStore('metadata').put(meta, 'singleton');
+      await tx.done?.catch(() => {});
+    }
+  }
+
+  private async getAudioFileHandle(extId: string, create: boolean) {
+    const audios = await this.getAudiosDir();
+    const safe = extId.replace(/[^A-Za-z0-9 .,_-]/g, '_');
+    return audios.getFileHandle(`${safe}.webm`, { create });
+  }
+
+  private async getAudiosDir() {
+    if (!this.dirHandle) throw new Error('no dir');
+    const gestor = await this.dirHandle.getDirectoryHandle('gestor');
+    const system = await gestor.getDirectoryHandle('system');
+    return system.getDirectoryHandle('audios');
+  }
+
+  private async getDataDir() {
+    if (!this.dirHandle) throw new Error('no dir');
+    const gestor = await this.dirHandle.getDirectoryHandle('gestor');
+    const system = await gestor.getDirectoryHandle('system');
+    return system.getDirectoryHandle('data');
+  }
+}

--- a/lib/audio/gestures.ts
+++ b/lib/audio/gestures.ts
@@ -1,0 +1,27 @@
+export function bindTapAndLongPress(
+  element: HTMLElement | SVGElement,
+  onTap: () => void,
+  onLongPress: () => void,
+  longPressMs = 700
+) {
+  let timer: number | null = null;
+  const cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+  element.addEventListener('pointerdown', () => {
+    timer = window.setTimeout(() => {
+      onLongPress();
+      timer = null;
+    }, longPressMs);
+  });
+  element.addEventListener('pointerup', () => {
+    if (timer) {
+      cancel();
+      onTap();
+    }
+  });
+  element.addEventListener('pointerleave', cancel);
+}

--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -1,0 +1,159 @@
+import { FileStore } from './fileStore';
+import { Recorder } from './recorder';
+import { Player } from './player';
+import { bindTapAndLongPress } from './gestures';
+import type { AttachAudioLayerOptions, MetadataFile, NodeState } from './types';
+
+interface AttachParams {
+  nodesSelection: Iterable<HTMLElement | SVGElement>;
+  getExtId: (el: HTMLElement | SVGElement) => string;
+  rootElement: HTMLElement | SVGElement;
+  options?: AttachAudioLayerOptions;
+}
+
+export function attachAudioLayer({ nodesSelection, getExtId, rootElement, options }: AttachParams) {
+  const store = new FileStore({ allowLocalFileSystem: options?.allowLocalFileSystem });
+  const recorder = new Recorder();
+  const player = new Player();
+  const state = new Map<string, NodeState>();
+  let metadata: MetadataFile = { schema_version: 1, nodes: {} };
+
+  const updateState = (extId: string, st: NodeState) => {
+    state.set(extId, st);
+    options?.onStateChange?.(extId, st);
+  };
+
+  const loadMetadata = async () => {
+    metadata = await store.readMeta();
+  };
+
+  const saveMetadata = async () => {
+    if (options?.autoSaveMetadata) {
+      await store.writeMeta(metadata);
+    }
+  };
+
+  const startRecording = async (extId: string) => {
+    try {
+      await recorder.start();
+      updateState(extId, 'recording');
+    } catch (e) {
+      options?.onError?.('E_MIC_DENIED', e);
+    }
+  };
+
+  const stopRecording = async (extId: string) => {
+    try {
+      const blob = await recorder.stop();
+      await store.writeAudio(extId, blob);
+      const duration = await getDuration(blob);
+      const now = new Date().toISOString();
+      metadata.nodes[extId] = {
+        extId,
+        local_path: `audios/${extId}.webm`,
+        duration_seconds: duration,
+        mime: blob.type,
+        created_at: now,
+        last_modified: now,
+      };
+      await saveMetadata();
+      updateState(extId, 'has-audio');
+    } catch (e) {
+      options?.onError?.('E_WRITE_FAIL', e);
+    }
+  };
+
+  const play = async (extId: string) => {
+    try {
+      const blob = await store.readAudio(extId);
+      if (!blob) throw new Error('missing');
+      if (player.playingExtId && player.playingExtId !== extId) {
+        player.pause();
+      }
+      await player.play(extId, blob);
+      updateState(extId, 'playing');
+      player.onEnded(() => updateState(extId, 'has-audio'));
+    } catch (e) {
+      options?.onError?.('E_READ_FAIL', e);
+    }
+  };
+
+  const pause = () => {
+    player.pause();
+    if (player.playingExtId) updateState(player.playingExtId, 'paused');
+  };
+
+  const del = async (extId: string) => {
+    await store.deleteAudio(extId);
+    metadata.nodes[extId] = null;
+    await saveMetadata();
+    updateState(extId, 'idle');
+  };
+
+  const download = async (extId: string) => {
+    const blob = await store.readAudio(extId);
+    if (!blob) return;
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${extId}.webm`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const bind = (el: HTMLElement | SVGElement) => {
+    const extId = getExtId(el);
+    bindTapAndLongPress(
+      el,
+      async () => {
+        const st = state.get(extId) || 'idle';
+        if (st === 'idle') await startRecording(extId);
+        else if (st === 'recording') await stopRecording(extId);
+        else if (st === 'has-audio') await play(extId);
+        else if (st === 'playing') pause();
+        else if (st === 'paused') await play(extId);
+      },
+      async () => {
+        const st = state.get(extId) || 'idle';
+        if (st === 'has-audio' || st === 'playing' || st === 'paused') {
+          await del(extId);
+        }
+      },
+      options?.longPressMs
+    );
+  };
+
+  for (const el of nodesSelection) bind(el);
+  store.init().then(loadMetadata);
+
+  return {
+    requestFolderPermission: async () => {
+      const ok = await store.requestFolderPermission();
+      if (ok) metadata = await store.readMeta();
+      return ok;
+    },
+    hasFolderAccess: () => store.hasAccess(),
+    startRecording,
+    stopRecording,
+    play,
+    pause,
+    delete: del,
+    download,
+    dispose: () => {
+      state.clear();
+    },
+  };
+}
+
+async function getDuration(blob: Blob): Promise<number> {
+  return new Promise(resolve => {
+    const audio = document.createElement('audio');
+    audio.src = URL.createObjectURL(blob);
+    audio.onloadedmetadata = () => {
+      const d = audio.duration;
+      URL.revokeObjectURL(audio.src);
+      resolve(isFinite(d) ? d : 0);
+    };
+    audio.onerror = () => resolve(0);
+  });
+}

--- a/lib/audio/player.ts
+++ b/lib/audio/player.ts
@@ -1,0 +1,27 @@
+export class Player {
+  private audio: HTMLAudioElement;
+  private currentExtId: string | null = null;
+
+  constructor() {
+    this.audio = new Audio();
+  }
+
+  async play(extId: string, src: Blob): Promise<void> {
+    if (this.audio.src) URL.revokeObjectURL(this.audio.src);
+    this.audio.src = URL.createObjectURL(src);
+    this.currentExtId = extId;
+    await this.audio.play();
+  }
+
+  pause() {
+    this.audio.pause();
+  }
+
+  onEnded(cb: () => void) {
+    this.audio.onended = cb;
+  }
+
+  get playingExtId() {
+    return this.currentExtId;
+  }
+}

--- a/lib/audio/recorder.ts
+++ b/lib/audio/recorder.ts
@@ -1,0 +1,31 @@
+export class Recorder {
+  private mediaRecorder?: MediaRecorder;
+  private chunks: BlobPart[] = [];
+  private mime = 'audio/webm;codecs=opus';
+
+  async start(): Promise<void> {
+    if (this.mediaRecorder?.state === 'recording') {
+      throw new Error('E_BUSY');
+    }
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.mediaRecorder = new MediaRecorder(stream, { mimeType: this.mime });
+    this.chunks = [];
+    this.mediaRecorder.ondataavailable = e => this.chunks.push(e.data);
+    this.mediaRecorder.start();
+  }
+
+  async stop(): Promise<Blob> {
+    if (!this.mediaRecorder) {
+      throw new Error('E_BUSY');
+    }
+    return new Promise(resolve => {
+      this.mediaRecorder!.addEventListener('stop', () => {
+        const blob = new Blob(this.chunks, { type: this.mime });
+        this.mediaRecorder?.stream.getTracks().forEach(t => t.stop());
+        this.mediaRecorder = undefined;
+        resolve(blob);
+      });
+      this.mediaRecorder.stop();
+    });
+  }
+}

--- a/lib/audio/types.ts
+++ b/lib/audio/types.ts
@@ -1,0 +1,29 @@
+export interface NodeAudioMeta {
+  extId: string;
+  local_path: string;
+  duration_seconds: number;
+  mime: string;
+  created_at: string;
+  last_modified: string;
+}
+
+export interface MetadataFile {
+  schema_version: number;
+  nodes: Record<string, NodeAudioMeta | null>;
+}
+
+export type NodeState =
+  | 'idle'
+  | 'recording'
+  | 'has-audio'
+  | 'playing'
+  | 'paused'
+  | 'error';
+
+export interface AttachAudioLayerOptions {
+  allowLocalFileSystem?: boolean;
+  autoSaveMetadata?: boolean;
+  longPressMs?: number;
+  onStateChange?: (extId: string, state: NodeState) => void;
+  onError?: (code: string, ctx?: unknown) => void;
+}


### PR DESCRIPTION
## Summary
- request persistent read/write access to a user-selected folder and store its handle
- expose folder access state to the audio layer and network graph
- add a "Configurar carpeta local" button to trigger permission request

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a24adc9df883308b4e57a30f0e8016