### PR TITLE
feat: add subject selection modal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}


### PR DESCRIPTION
## Summary
- add dataset for Álgebra, Cálculo, and POO subjects
- show startup modal to load local folder and pick subject

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a3dc0b45b88330a99a0a573ddd276b