### PR TITLE
feat: add subject selection modal

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -96,6 +96,15 @@ export default function NetworkGraph() {
   const [folderReady, setFolderReady] = useState(false)
   const [selectedSubject, setSelectedSubject] = useState<string | null>(null)
   const subjectMapsRef = useRef<Record<string, SubjectMap[]>>(INITIAL_SUBJECT_MAPS)
+  const subjectGroupsRef = useRef<Record<string, Group[]>>({
+    algebra: [{ id: "algebra", name: "Álgebra", color: "#3b82f6" }],
+    calculo: [{ id: "calculo", name: "Cálculo", color: "#ef4444" }],
+    poo: [{
+      id: "poo",
+      name: "Programación Orientada a Objetos",
+      color: "#10b981",
+    }],
+  })
   const [currentMapIndex, setCurrentMapIndex] = useState<Record<string, number>>({
     algebra: 0,
     calculo: 0,
@@ -117,8 +126,9 @@ export default function NetworkGraph() {
     const map = maps[idx]
     setNodes(map.nodes)
     setLinks(map.links)
-    setGroups([{ id, name: subject.name, color: subject.color }])
-    setCurrentGroup(id)
+    const g = subjectGroupsRef.current[id]
+    setGroups(g)
+    setCurrentGroup(g[0]?.id || "")
     setShowAllGroups(false)
     setIsConfigDialogOpen(false)
   }
@@ -162,6 +172,12 @@ export default function NetworkGraph() {
   useEffect(() => {
     setIsMounted(true)
   }, [])
+
+  useEffect(() => {
+    if (selectedSubject) {
+      subjectGroupsRef.current[selectedSubject] = groups
+    }
+  }, [groups, selectedSubject])
 
   const getVisibleNodes = useCallback(() => {
     if (showAllGroups) {
@@ -215,6 +231,12 @@ export default function NetworkGraph() {
       color: groupData.color,
     }
 
+    if (nodes.length === 0 && svgRef.current) {
+      const { width, height } = svgRef.current.getBoundingClientRect()
+      newNode.x = width / 2
+      newNode.y = height / 2
+    }
+
     const newLinks = nodes.map((n) => ({ source: newNode.id, target: n.id }))
 
     setNodes((prev) => [...prev, newNode])
@@ -251,7 +273,6 @@ export default function NetworkGraph() {
             event.preventDefault()
             event.stopPropagation()
             setIsGroupDialogOpen(true)
-            setNodePadding((p) => p + 5)
           }
           break
       }


### PR DESCRIPTION
## Summary
- keep separate graphs for Álgebra, Cálculo, and POO
- create a new empty map with the right arrow key and prompt for node name
- allow selecting a folder before choosing a subject

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a3dc0b45b88330a99a0a573ddd276b