### PR TITLE
feat: enable map back arrow to return to subject selection

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -288,7 +288,12 @@ export default function NetworkGraph() {
     setIsConfigDialogOpen(false)
   }
 
-  const handleBack = useCallback(() => {
+  const handleMapBack = useCallback(() => {
+    setSelectedSubject(null)
+    setIsConfigDialogOpen(true)
+  }, [])
+
+  const handleConfigBack = useCallback(() => {
     if (selectedSubject) {
       setSelectedSubject(null)
     } else if (selectedWeek) {
@@ -298,7 +303,6 @@ export default function NetworkGraph() {
       setSelectedWeek(null)
       setSelectedSubject(null)
     }
-    setIsConfigDialogOpen(true)
   }, [selectedSubject, selectedWeek, folderReady])
 
   const deleteGroup = (id: string) => {
@@ -826,11 +830,11 @@ export default function NetworkGraph() {
   return (
     <div className="w-full h-screen bg-gray-50 dark:bg-gray-900 relative overflow-hidden">
       <svg ref={svgRef} width="100%" height="100%" className="bg-gray-50 dark:bg-gray-900" />
-      {(folderReady || selectedWeek || selectedSubject) && (
+      {selectedSubject && (
         <Button
           className="absolute top-4 left-4 z-[60]"
           variant="outline"
-          onClick={handleBack}
+          onClick={handleMapBack}
         >
           ←
         </Button>
@@ -840,7 +844,11 @@ export default function NetworkGraph() {
         <DialogContent>
           <DialogHeader className="flex items-center gap-2">
             {(folderReady || selectedWeek || selectedSubject) && (
-              <Button variant="outline" onClick={handleBack} className="px-2">
+              <Button
+                variant="outline"
+                onClick={handleConfigBack}
+                className="px-2"
+              >
                 ←
               </Button>
             )}


### PR DESCRIPTION
## Summary
- Implement back arrow on map to reopen subject selection
- Add separate handlers for map navigation and dialog navigation

## Testing
- `pnpm lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a65fc150188330a412f3b87766638f