### PR TITLE
feat: back arrow returns to subject selection

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -288,6 +288,11 @@ export default function NetworkGraph() {
     setIsConfigDialogOpen(false)
   }
 
+  const handleBackToSubjects = useCallback(() => {
+    setSelectedSubject(null)
+    setIsConfigDialogOpen(true)
+  }, [])
+
   const handleBack = useCallback(() => {
     if (selectedSubject) {
       setSelectedSubject(null)
@@ -826,11 +831,11 @@ export default function NetworkGraph() {
   return (
     <div className="w-full h-screen bg-gray-50 dark:bg-gray-900 relative overflow-hidden">
       <svg ref={svgRef} width="100%" height="100%" className="bg-gray-50 dark:bg-gray-900" />
-      {(folderReady || selectedWeek || selectedSubject) && (
+      {selectedSubject && !isConfigDialogOpen && (
         <Button
           className="absolute top-4 left-4 z-[60]"
           variant="outline"
-          onClick={handleBack}
+          onClick={handleBackToSubjects}
         >
           ←
         </Button>


### PR DESCRIPTION
## Summary
- show back arrow only on map view
- back arrow opens subject selection tab

## Testing
- `pnpm lint` *(fails: requires Next.js ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a65fc150188330a412f3b87766638f