### PR TITLE
fix: persist nodes in folder and enable file upload

### DIFF
--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -90,6 +90,26 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
     updateState(extId, 'idle');
   };
 
+  const upload = async (extId: string, blob: Blob) => {
+    try {
+      await store.writeAudio(extId, blob);
+      const duration = await getDuration(blob);
+      const now = new Date().toISOString();
+      metadata.nodes[extId] = {
+        extId,
+        local_path: `audios/${extId}.webm`,
+        duration_seconds: duration,
+        mime: blob.type,
+        created_at: now,
+        last_modified: now,
+      };
+      await saveMetadata();
+      updateState(extId, 'has-audio');
+    } catch (e) {
+      options?.onError?.('E_WRITE_FAIL', e);
+    }
+  };
+
   const download = async (extId: string) => {
     const blob = await store.readAudio(extId);
     if (!blob) return;
@@ -123,7 +143,9 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
     );
   };
 
-  for (const el of nodesSelection) bind(el);
+  if (options?.bindGestures !== false) {
+    for (const el of nodesSelection) bind(el);
+  }
   store.init().then(loadMetadata);
 
   return {
@@ -139,6 +161,9 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
     pause,
     delete: del,
     download,
+    upload,
+    readData: (name: string) => store.readJson(name),
+    writeData: (name: string, data: any) => store.writeJson(name, data),
     dispose: () => {
       state.clear();
     },

--- a/lib/audio/types.ts
+++ b/lib/audio/types.ts
@@ -24,6 +24,7 @@ export interface AttachAudioLayerOptions {
   allowLocalFileSystem?: boolean;
   autoSaveMetadata?: boolean;
   longPressMs?: number;
+  bindGestures?: boolean;
   onStateChange?: (extId: string, state: NodeState) => void;
   onError?: (code: string, ctx?: unknown) => void;
 }


### PR DESCRIPTION
## Summary
- persist weeks and subject maps to chosen folder using the audio layer store
- allow selecting audio files for nodes in addition to drag-and-drop
- expose JSON read/write helpers in audio layer and backend store

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: requires ESLint configuration)
- `npx tsc -p tsconfig.json --noEmit` (fails: multiple type errors)


------
https://chatgpt.com/codex/tasks/task_e_68a72094d6508330b14afe0491644d53