### PR TITLE
feat: persist folder config and drag-drop audio

### DIFF
--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -45,7 +45,7 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
   const stopRecording = async (extId: string) => {
     try {
       const blob = await recorder.stop();
-      await store.writeAudio(extId, blob);
+      await store.writeAudio(extId, blob, 'webm');
       const duration = await getDuration(blob);
       const now = new Date().toISOString();
       metadata.nodes[extId] = {
@@ -65,7 +65,9 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const play = async (extId: string) => {
     try {
-      const blob = await store.readAudio(extId);
+      const meta = metadata.nodes[extId];
+      const ext = meta?.local_path?.split('.').pop() || 'webm';
+      const blob = await store.readAudio(extId, ext);
       if (!blob) throw new Error('missing');
       if (player.playingExtId && player.playingExtId !== extId) {
         player.pause();
@@ -84,19 +86,23 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
   };
 
   const del = async (extId: string) => {
-    await store.deleteAudio(extId);
+    const meta = metadata.nodes[extId];
+    const ext = meta?.local_path?.split('.').pop() || 'webm';
+    await store.deleteAudio(extId, ext);
     metadata.nodes[extId] = null;
     await saveMetadata();
     updateState(extId, 'idle');
   };
 
   const download = async (extId: string) => {
-    const blob = await store.readAudio(extId);
+    const meta = metadata.nodes[extId];
+    const ext = meta?.local_path?.split('.').pop() || 'webm';
+    const blob = await store.readAudio(extId, ext);
     if (!blob) return;
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `${extId}.webm`;
+    a.download = `${extId}.${ext}`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -121,18 +127,48 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
       },
       options?.longPressMs
     );
+
+    el.addEventListener('dragover', e => {
+      e.preventDefault();
+    });
+
+    el.addEventListener('drop', async e => {
+      e.preventDefault();
+      const file = e.dataTransfer?.files?.[0];
+      if (!file) return;
+      try {
+        const ext = file.name.split('.').pop()?.toLowerCase() || 'webm';
+        await store.writeAudio(extId, file, ext);
+        const duration = await getDuration(file);
+        const now = new Date().toISOString();
+        metadata.nodes[extId] = {
+          extId,
+          local_path: `audios/${extId}.${ext}`,
+          duration_seconds: duration,
+          mime: file.type,
+          created_at: now,
+          last_modified: now,
+        };
+        await saveMetadata();
+        updateState(extId, 'has-audio');
+      } catch (err) {
+        options?.onError?.('E_WRITE_FAIL', err);
+      }
+    });
   };
 
   for (const el of nodesSelection) bind(el);
-  store.init().then(loadMetadata);
+  const ready = store.init().then(loadMetadata).then(() => store.hasAccess());
 
   return {
+    ready,
     requestFolderPermission: async () => {
       const ok = await store.requestFolderPermission();
       if (ok) metadata = await store.readMeta();
       return ok;
     },
     hasFolderAccess: () => store.hasAccess(),
+    getFolderName: () => store.getDirName(),
     startRecording,
     stopRecording,
     play,

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,20 @@
+export interface AppConfig {
+  folderName?: string;
+}
+
+const KEY = 'appConfig';
+
+export function loadConfig(): AppConfig {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveConfig(cfg: AppConfig) {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(KEY, JSON.stringify(cfg));
+}


### PR DESCRIPTION
## Summary
- persist selected folder configuration locally and reload on startup
- allow importing audio files via drag and drop to nodes, storing copies locally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompt `How would you like to configure ESLint?`)*

------
https://chatgpt.com/codex/tasks/task_e_68a7745dbd608330b14228711ddfe6ad