### PR TITLE
feat: persist config and support audio drag drop

### DIFF
--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -101,6 +101,26 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
     URL.revokeObjectURL(url);
   };
 
+  const importFile = async (extId: string, file: File) => {
+    try {
+      await store.writeAudio(extId, file);
+      const duration = await getDuration(file);
+      const now = new Date().toISOString();
+      metadata.nodes[extId] = {
+        extId,
+        local_path: `audios/${extId}.webm`,
+        duration_seconds: duration,
+        mime: file.type,
+        created_at: now,
+        last_modified: now,
+      };
+      await saveMetadata();
+      updateState(extId, 'has-audio');
+    } catch (e) {
+      options?.onError?.('E_WRITE_FAIL', e);
+    }
+  };
+
   const bind = (el: HTMLElement | SVGElement) => {
     const extId = getExtId(el);
     bindTapAndLongPress(
@@ -121,6 +141,14 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
       },
       options?.longPressMs
     );
+    el.addEventListener('dragover', e => {
+      e.preventDefault();
+    });
+    el.addEventListener('drop', e => {
+      e.preventDefault();
+      const file = e.dataTransfer?.files?.[0];
+      if (file) importFile(extId, file);
+    });
   };
 
   for (const el of nodesSelection) bind(el);
@@ -133,12 +161,15 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
       return ok;
     },
     hasFolderAccess: () => store.hasAccess(),
+    readConfig: <T>() => store.readConfig<T>(),
+    writeConfig: <T>(cfg: T) => store.writeConfig(cfg),
     startRecording,
     stopRecording,
     play,
     pause,
     delete: del,
     download,
+    importFile,
     dispose: () => {
       state.clear();
     },


### PR DESCRIPTION
## Summary
- store app config in selected local folder for full offline persistence
- allow dropping audio files onto nodes and save them to the local folder

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68a7745dbd608330b14228711ddfe6ad