### PR TITLE
feat: persist config, drag-drop audio, and theme palettes

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -74,6 +74,27 @@
   --sidebar-ring: oklch(0.439 0 0);
 }
 
+.blue {
+  --background: #1e3a8a;
+  --foreground: #f8fafc;
+  --primary: #3b82f6;
+  --primary-foreground: #f8fafc;
+}
+
+.emerald {
+  --background: #064e3b;
+  --foreground: #f0fdf4;
+  --primary: #10b981;
+  --primary-foreground: #f0fdf4;
+}
+
+.rose {
+  --background: #881337;
+  --foreground: #fff1f2;
+  --primary: #f43f5e;
+  --primary-foreground: #fff1f2;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { GeistSans } from 'geist/font/sans'
 import { GeistMono } from 'geist/font/mono'
 import './globals.css'
+import { ThemeProvider } from '@/components/theme-provider'
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -25,7 +26,11 @@ html {
 }
         `}</style>
       </head>
-      <body>{children}</body>
+      <body>
+        <ThemeProvider attribute="class" defaultTheme="light" disableTransitionOnChange>
+          {children}
+        </ThemeProvider>
+      </body>
     </html>
   )
 }


### PR DESCRIPTION
## Summary
- store app config and theme in selected local folder for full offline persistence
- allow dropping audio files onto nodes and save them to the local folder
- let users choose light, dark, blue, emerald, or rose palettes and remember their selection
- keep uploaded audio available across sessions by reloading node states from saved metadata
- switch node label text to theme foreground color for better contrast

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_68a7745dbd608330b14228711ddfe6ad