### PR TITLE
Fix mismatched braces causing build failure

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -1172,5 +1172,6 @@ audioLayer.ready.then((has) => {
         </DialogContent>
       </Dialog>
     </div>
-  )
+  );
+};
 }

--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -176,20 +176,20 @@ export class FileStore {
   }
 
   async deleteAudio(extId: string, ext = 'webm'): Promise<void> {
-if (this.dirHandle) {
-  try {
-    const file = await this.getAudioFileHandle(extId, ext, false);
-    await file.remove?.();
-  } catch {
-    /* ignore */
+  if (this.dirHandle) {
+    try {
+      const file = await this.getAudioFileHandle(extId, ext, false);
+      await file.remove?.();
+    } catch {
+      /* ignore */
+    }
+  } else {
+    const db = await this.openDB();
+    const tx = db.transaction('audios', 'readwrite');
+    tx.objectStore('audios').delete(extId);
+    await (tx as any).done?.catch(() => {});
   }
-} else {
-  const db = await this.openDB();
-  const tx = db.transaction('audios', 'readwrite');
-  tx.objectStore('audios').delete(extId);
-  await (tx as any).done?.catch(() => {});
-}
-
+  }
 
   async readMeta(): Promise<MetadataFile> {
     if (this.dirHandle) {


### PR DESCRIPTION
## Summary
- close dangling braces in NetworkGraph component
- add missing closing brace in audio FileStore deleteAudio method

## Testing
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a799fad9b883309fddae711afb397f