### PR TITLE
Fix unclosed blocks causing build failure

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -417,18 +417,18 @@ export default function NetworkGraph() {
     return false
   }, [])
 
-  const handleFolderClick = async () => {
+const handleFolderClick = async () => {
     await ensureAudioLayer()
     const ok = await audioLayerRef.current?.requestFolderPermission()
     setFolderReady(!!ok)
-if (ok) {
-  const name = audioLayerRef.current?.getFolderName() || ""
-  setFolderName(name)
-  saveConfig({ folderName: name })
-  await loadPersistedData()
-  setStep(1)
-}
-
+    if (ok) {
+      const name = audioLayerRef.current?.getFolderName() || ""
+      setFolderName(name)
+      saveConfig({ folderName: name })
+      await loadPersistedData()
+      setStep(1)
+    }
+  }
 
   useEffect(() => {
     setIsMounted(true)

--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -176,20 +176,20 @@ export class FileStore {
   }
 
   async deleteAudio(extId: string, ext = 'webm'): Promise<void> {
-if (this.dirHandle) {
-  try {
-    const file = await this.getAudioFileHandle(extId, ext, false);
-    await file.remove?.();
-  } catch {
-    /* ignore */
+    if (this.dirHandle) {
+      try {
+        const file = await this.getAudioFileHandle(extId, ext, false);
+        await file.remove?.();
+      } catch {
+        /* ignore */
+      }
+    } else {
+      const db = await this.openDB();
+      const tx = db.transaction('audios', 'readwrite');
+      tx.objectStore('audios').delete(extId);
+      await (tx as any).done?.catch(() => {});
+    }
   }
-} else {
-  const db = await this.openDB();
-  const tx = db.transaction('audios', 'readwrite');
-  tx.objectStore('audios').delete(extId);
-  await (tx as any).done?.catch(() => {});
-}
-
 
   async readMeta(): Promise<MetadataFile> {
     if (this.dirHandle) {


### PR DESCRIPTION
## Summary
- close `handleFolderClick` block in network graph component
- close `deleteAudio` method in file store utility

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68a79dc708a483309d45c0de3f986dfb