### PR TITLE
Fix deployment build by closing unbalanced braces

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -421,14 +421,14 @@ export default function NetworkGraph() {
     await ensureAudioLayer()
     const ok = await audioLayerRef.current?.requestFolderPermission()
     setFolderReady(!!ok)
-if (ok) {
-  const name = audioLayerRef.current?.getFolderName() || ""
-  setFolderName(name)
-  saveConfig({ folderName: name })
-  await loadPersistedData()
-  setStep(1)
-}
-
+    if (ok) {
+      const name = audioLayerRef.current?.getFolderName() || ""
+      setFolderName(name)
+      saveConfig({ folderName: name })
+      await loadPersistedData()
+      setStep(1)
+    }
+  }
 
   useEffect(() => {
     setIsMounted(true)

--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -176,20 +176,20 @@ export class FileStore {
   }
 
   async deleteAudio(extId: string, ext = 'webm'): Promise<void> {
-if (this.dirHandle) {
-  try {
-    const file = await this.getAudioFileHandle(extId, ext, false);
-    await file.remove?.();
-  } catch {
-    /* ignore */
+    if (this.dirHandle) {
+      try {
+        const file = await this.getAudioFileHandle(extId, ext, false);
+        await file.remove?.();
+      } catch {
+        /* ignore */
+      }
+    } else {
+      const db = await this.openDB();
+      const tx = db.transaction('audios', 'readwrite');
+      tx.objectStore('audios').delete(extId);
+      await (tx as any).done?.catch(() => {});
+    }
   }
-} else {
-  const db = await this.openDB();
-  const tx = db.transaction('audios', 'readwrite');
-  tx.objectStore('audios').delete(extId);
-  await (tx as any).done?.catch(() => {});
-}
-
 
   async readMeta(): Promise<MetadataFile> {
     if (this.dirHandle) {


### PR DESCRIPTION
## Summary
- Close the `handleFolderClick` function in the network graph component to resolve syntax errors
- Close `deleteAudio` function in the audio file store to fix missing brace

## Testing
- `pnpm run build`
- `pnpm lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a79dc708a483309d45c0de3f986dfb