### PR TITLE
Ensure node additions persist to config

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -640,16 +640,22 @@ const handleFolderClick = async () => {
     setShowAllGroups(false)
     setNewNodePos(null)
 
-    if (selectedWeek && selectedSubject && isAwaitingMap) {
+    if (selectedWeek && selectedSubject) {
       const maps = weekSubjectMapsRef.current[selectedWeek][selectedSubject]
-      maps.push({ nodes: updatedNodes, links: updatedLinks, groups })
-      weekCurrentMapIndexRef.current[selectedWeek][selectedSubject] =
-        maps.length - 1
-      setCurrentMapIndex((prev) => ({
-        ...prev,
-        [selectedSubject]: maps.length - 1,
-      }))
-      setIsAwaitingMap(false)
+      if (isAwaitingMap) {
+        maps.push({ nodes: updatedNodes, links: updatedLinks, groups })
+        weekCurrentMapIndexRef.current[selectedWeek][selectedSubject] =
+          maps.length - 1
+        setCurrentMapIndex((prev) => ({
+          ...prev,
+          [selectedSubject]: maps.length - 1,
+        }))
+        setIsAwaitingMap(false)
+      } else {
+        const idx =
+          currentMapIndex[selectedSubject] ?? maps.length - 1
+        maps[idx] = { nodes: updatedNodes, links: updatedLinks, groups }
+      }
       saveCurrentSubjectData()
     }
   }, [
@@ -662,6 +668,7 @@ const handleFolderClick = async () => {
     selectedWeek,
     selectedSubject,
     isAwaitingMap,
+    currentMapIndex,
     saveCurrentSubjectData,
   ])
 


### PR DESCRIPTION
## Summary
- Update `addNode` to persist new nodes and links to the current map immediately
- Handle both new maps and existing maps, saving configuration after each addition

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68ab721994f48330a556238cde9aea26