### PR TITLE
fix: reset map awaiting state

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -295,6 +295,7 @@ export default function NetworkGraph() {
   const selectWeek = (id: string) => {
     setSelectedWeek(id)
     setCurrentMapIndex({ ...weekCurrentMapIndexRef.current[id] })
+    setIsAwaitingMap(false)
     setStep(2)
   }
 
@@ -358,10 +359,12 @@ export default function NetworkGraph() {
     setCurrentGroup(map.groups[0]?.id || "")
     setShowAllGroups(false)
     setIsConfigDialogOpen(false)
+    setIsAwaitingMap(false)
     setStep(3)
   }
 
   const handleBack = useCallback(() => {
+    setIsAwaitingMap(false)
     if (step === 3) {
       saveCurrentSubjectData()
       setSelectedSubject(null)


### PR DESCRIPTION
## Summary
- reset awaiting map creation state when changing week, selecting existing subject map, or navigating back

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm add -D eslint` *(fails: GET https://registry.npmjs.org/eslint: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e5c37f48330b7aae8bfba191336