### PR TITLE
Fix node creation after clearing subject maps

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -485,22 +485,33 @@ const handleFolderClick = async () => {
     maps[idx].groups = groups
     if (nodes.length === 0) {
       maps.splice(idx, 1)
-      const newIdx = idx > 0 ? idx - 1 : 0
-      weekCurrentMapIndexRef.current[selectedWeek][selectedSubject] = newIdx
-      setCurrentMapIndex((prev) => ({ ...prev, [selectedSubject]: newIdx }))
-      if (maps[newIdx]) {
-        setNodes(maps[newIdx].nodes)
-        setLinks(maps[newIdx].links)
-        setGroups(maps[newIdx].groups)
-        setCurrentGroup(maps[newIdx].groups[0]?.id || "")
-      } else {
+      if (maps.length === 0) {
+        weekCurrentMapIndexRef.current[selectedWeek][selectedSubject] = 0
+        setCurrentMapIndex((prev) => {
+          const { [selectedSubject]: _removed, ...rest } = prev
+          return rest
+        })
+        localStorage.removeItem(
+          `subjectMaps_${selectedWeek}_${selectedSubject}`,
+        )
+        localStorage.removeItem(
+          `currentMapIndex_${selectedWeek}_${selectedSubject}`,
+        )
         const defaultGroups = JSON.parse(
           JSON.stringify(INITIAL_SUBJECT_GROUPS[selectedSubject] || []),
         )
         setGroups(defaultGroups)
         setCurrentGroup(defaultGroups[0]?.id || "")
         setIsAwaitingMap(true)
+        return
       }
+      const newIdx = idx > 0 ? idx - 1 : 0
+      weekCurrentMapIndexRef.current[selectedWeek][selectedSubject] = newIdx
+      setCurrentMapIndex((prev) => ({ ...prev, [selectedSubject]: newIdx }))
+      setNodes(maps[newIdx].nodes)
+      setLinks(maps[newIdx].links)
+      setGroups(maps[newIdx].groups)
+      setCurrentGroup(maps[newIdx].groups[0]?.id || "")
     }
     saveCurrentSubjectData()
   }, [


### PR DESCRIPTION
## Summary
- reset map index and localStorage when deleting the last node so maps can be recreated

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*
- `pnpm build` *(fails: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7e5c37f48330b7aae8bfba191336