### PR TITLE
Verify audio file persistence

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -856,7 +856,21 @@ const handleFolderClick = async () => {
       nodesSelection: nodeElements.nodes(),
       getExtId: (el) => (el as any).__data__.id,
       rootElement: svgElement,
-      options: { allowLocalFileSystem: true, autoSaveMetadata: true },
+      options: {
+        allowLocalFileSystem: true,
+        autoSaveMetadata: true,
+        // Surface audio layer errors to the user. In particular we notify
+        // when a recording could not be persisted after stopping.
+        onError: (code) => {
+          if (code === 'E_WRITE_VERIFY_FAIL') {
+            alert(
+              'No se pudo guardar el audio. Verifica los permisos de la carpeta.'
+            )
+          } else {
+            alert(`Error de audio: ${code}`)
+          }
+        },
+      },
     })
 audioLayerRef.current = audioLayer
 audioLayer.ready.then((has) => {


### PR DESCRIPTION
## Summary
- verify recorded audio files are actually saved and flag an error if not
- alert the user when audio saving fails due to missing permissions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab817a46848330a44ab62ed5b9b959