### PR TITLE
Add placeholder node and audio state icons

### DIFF
--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -38,6 +38,7 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const startRecording = async (extId: string) => {
     try {
+      console.log('#graba');
       await recorder.start();
       updateState(extId, 'recording');
     } catch (e) {
@@ -47,7 +48,9 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const stopRecording = async (extId: string) => {
     try {
+      console.log('#corta grabacion');
       const blob = await recorder.stop();
+      console.log('#intentando guardar');
       await store.writeAudio(extId, blob, 'webm');
       const duration = await getDuration(blob);
       const now = new Date().toISOString();
@@ -60,8 +63,13 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
         last_modified: now,
       };
       await saveMetadata();
+      const folder = store.getDirName();
+      const path = `${folder ? folder + '/' : ''}gestor/system/audios/${extId}.webm`;
+      console.log(`#guardado en ${path}`);
       updateState(extId, 'has-audio');
     } catch (e) {
+      console.log('#error al guardar');
+      updateState(extId, 'error');
       options?.onError?.('E_WRITE_FAIL', e);
     }
   };
@@ -134,6 +142,7 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
   };
 
   const bind = (el: HTMLElement | SVGElement) => {
+    if ((el as any).dataset?.placeholder === 'true') return;
     const extId = getExtId(el);
     bindTapAndLongPress(
       el,


### PR DESCRIPTION
## Summary
- Ensure a default "Ingresa nombre" node appears when a map has no nodes
- Show emoji state icons on nodes for recording, playback, pause, and errors
- Log recording lifecycle events including save path and handle placeholder nodes separately

## Testing
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9bf1eee48330821692d013a4d20d