### PR TITLE
Add default node and audio state icons

### DIFF
--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -265,6 +265,14 @@ export class FileStore {
     return this.dirHandle?.name ?? null;
   }
 
+  getAudioPath(extId: string, ext = 'webm'): string {
+    const safe = extId.replace(/[^A-Za-z0-9 .,_-]/g, '_');
+    if (this.dirHandle) {
+      return `${this.dirHandle.name}/gestor/system/audios/${safe}.${ext}`;
+    }
+    return `audios/${safe}.${ext}`;
+  }
+
   private async getAudiosDir() {
     if (!this.dirHandle) throw new Error('no dir');
     const gestor = await this.dirHandle.getDirectoryHandle('gestor');

--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -38,17 +38,23 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const startRecording = async (extId: string) => {
     try {
+      console.log('#graba')
       await recorder.start();
       updateState(extId, 'recording');
     } catch (e) {
+      console.error('#error', e)
       options?.onError?.('E_MIC_DENIED', e);
     }
   };
 
   const stopRecording = async (extId: string) => {
     try {
+      console.log('#corta grabacion')
       const blob = await recorder.stop();
+      console.log('#intentando guardar')
       await store.writeAudio(extId, blob, 'webm');
+      const path = store.getAudioPath(extId, 'webm');
+      console.log(`#guardado en ${path}`);
       const duration = await getDuration(blob);
       const now = new Date().toISOString();
       metadata.nodes[extId] = {
@@ -62,6 +68,7 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
       await saveMetadata();
       updateState(extId, 'has-audio');
     } catch (e) {
+      console.error('#error', e)
       options?.onError?.('E_WRITE_FAIL', e);
     }
   };


### PR DESCRIPTION
## Summary
- add placeholder node when map is empty and allow renaming on tap
- show emoji icons for node audio states and log recording lifecycle
- expose helper to report full audio file path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Could not find a declaration file for module 'd3', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9bf1eee48330821692d013a4d20d