### PR TITLE
Add default node and audio state emotes

### DIFF
--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -147,12 +147,11 @@ export class FileStore {
   async writeConfig<T = any>(cfg: T): Promise<void> {
     if (this.dirHandle) {
       const dataDir = await this.getDataDir();
-      const tmp = await dataDir.getFileHandle('config.tmp.json', { create: true });
-      const writable = await (tmp as any).createWritable();
+      await dataDir.removeEntry?.('config.tmp.json').catch(() => {});
+      const file = await dataDir.getFileHandle('config.json', { create: true });
+      const writable = await (file as any).createWritable({ keepExistingData: false });
       await writable.write(JSON.stringify(cfg));
       await writable.close();
-      await dataDir.removeEntry?.('config.json').catch(() => {});
-      await (tmp as any).move?.('config.json');
     } else {
       const db = await this.openDB();
       const tx = db.transaction('config', 'readwrite');

--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -38,6 +38,7 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const startRecording = async (extId: string) => {
     try {
+      console.log('#graba');
       await recorder.start();
       updateState(extId, 'recording');
     } catch (e) {
@@ -47,7 +48,9 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const stopRecording = async (extId: string) => {
     try {
+      console.log('#corta grabacion');
       const blob = await recorder.stop();
+      console.log('#intentando guardar');
       await store.writeAudio(extId, blob, 'webm');
       const duration = await getDuration(blob);
       const now = new Date().toISOString();
@@ -61,7 +64,13 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
       };
       await saveMetadata();
       updateState(extId, 'has-audio');
+      const base = store.getDirName();
+      const path = base
+        ? `${base}/gestor/system/audios/${extId}.webm`
+        : `gestor/system/audios/${extId}.webm`;
+      console.log(`#guardado en ${path}`);
     } catch (e) {
+      updateState(extId, 'error');
       options?.onError?.('E_WRITE_FAIL', e);
     }
   };


### PR DESCRIPTION
## Summary
- ensure an "Ingresa nombre" node exists when maps are empty
- display emoji indicators for audio state and log recording/save steps
- add descriptions to all dialogs to silence accessibility warnings
- write config.json directly to avoid file locking errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab9bf1eee48330821692d013a4d20d