### PR TITLE
Add default node and audio state emotes

### DIFF
--- a/components/network-graph.tsx
+++ b/components/network-graph.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useRef, useState, useCallback } from "react"
 import * as d3 from "d3"
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Button } from "@/components/ui/button"
 import { attachAudioLayer } from "@/lib/audio"
+import type { NodeState } from "@/lib/audio/types"
 import { useTheme } from "next-themes"
 import { loadConfig, saveConfig } from "@/lib/config"
 
@@ -109,6 +110,15 @@ const DEFAULT_WEEKS = [
   { id: "week2", name: "Semana 2" },
 ]
 
+const STATE_EMOJI: Record<NodeState, string> = {
+  idle: "⏺️",
+  recording: "🔴",
+  "has-audio": "▶️",
+  playing: "⏸️",
+  paused: "▶️",
+  error: "⚠️",
+}
+
 const createDefaultConfig = (): PersistedConfig => {
   const weekSubjectMaps: Record<string, Record<string, SubjectMap[]>> = {}
   const weekCurrentMapIndex: Record<string, Record<string, number>> = {}
@@ -172,6 +182,22 @@ export default function NetworkGraph() {
   const DELETE_DISTANCE = 150
 
   const simulationRef = useRef<d3.Simulation<GraphNode, Link> | null>(null)
+
+  useEffect(() => {
+    if (nodes.length === 0 && groups.length > 0) {
+      const g = groups[0]
+      const placeholder: GraphNode = {
+        id: `default-${Date.now()}`,
+        name: "Ingresa nombre",
+        group: g.id,
+        color: g.color,
+        x: window.innerWidth / 2,
+        y: window.innerHeight / 2,
+      }
+      setNodes([placeholder])
+      setLinks([])
+    }
+  }, [nodes, groups])
 
   const randomColor = () =>
     "#" + Math.floor(Math.random() * 16777215).toString(16).padStart(6, "0")
@@ -808,6 +834,20 @@ const handleFolderClick = async () => {
       .attr("cy", (d) => d.y ?? height / 2)
       .style("cursor", "pointer")
 
+    const iconsGroup = container.append("g").attr("class", "node-icons")
+    const iconElements = iconsGroup
+      .selectAll("text")
+      .data(nodesCopy)
+      .enter()
+      .append("text")
+      .attr("class", "node-icon")
+      .attr("data-id", (d) => d.id)
+      .attr("text-anchor", "middle")
+      .attr("alignment-baseline", "middle")
+      .attr("font-size", 16)
+      .style("pointer-events", "none")
+      .text(STATE_EMOJI.idle)
+
     nodeElements.call(
       d3
         .drag<SVGCircleElement, GraphNode>()
@@ -856,7 +896,18 @@ const handleFolderClick = async () => {
       nodesSelection: nodeElements.nodes(),
       getExtId: (el) => (el as any).__data__.id,
       rootElement: svgElement,
-      options: { allowLocalFileSystem: true, autoSaveMetadata: true },
+      options: {
+        allowLocalFileSystem: true,
+        autoSaveMetadata: true,
+        onStateChange: (id, st) => {
+          d3.select(svgElement)
+            .select(`text.node-icon[data-id='${id}']`)
+            .text(STATE_EMOJI[st])
+        },
+        onError: (code) => {
+          console.error("#error", code)
+        },
+      },
     })
 audioLayerRef.current = audioLayer
 audioLayer.ready.then((has) => {
@@ -888,8 +939,9 @@ audioLayer.ready.then((has) => {
       const linkNodes = linkElements.nodes()
       const nodeNodes = nodeElements.nodes()
       const labelNodes = labelElements.nodes()
+      const iconNodes = iconElements.nodes()
 
-      if (!nodeNodes.length || !labelNodes.length) {
+      if (!nodeNodes.length || !labelNodes.length || !iconNodes.length) {
         console.log("[v0] Elements not available during tick, stopping simulation")
         simulation.stop()
         return
@@ -916,6 +968,12 @@ audioLayer.ready.then((has) => {
         return
       }
 
+      if (!iconNodes.every(isValidDomNode)) {
+        console.log("[v0] Invalid icon elements detected, stopping simulation")
+        simulation.stop()
+        return
+      }
+
       try {
         linkElements
           .attr("x1", (d: any) => {
@@ -938,6 +996,10 @@ audioLayer.ready.then((has) => {
           nodeElements
             .attr("cx", (d: any) => d.x || 0)
             .attr("cy", (d: any) => d.y || 0)
+
+          iconElements
+            .attr("x", (d: any) => d.x || 0)
+            .attr("y", (d: any) => d.y || 0)
 
           labelElements
             .attr("x", (d: any) => d.x || 0)
@@ -1018,13 +1080,18 @@ audioLayer.ready.then((has) => {
                 ←
               </Button>
             )}
-            <DialogTitle>
-              {step === 0
-                ? "Configura carpeta"
-                : step === 1
-                ? "Selecciona semana"
-                : "Selecciona materia"}
-            </DialogTitle>
+            <div>
+              <DialogTitle>
+                {step === 0
+                  ? "Configura carpeta"
+                  : step === 1
+                  ? "Selecciona semana"
+                  : "Selecciona materia"}
+              </DialogTitle>
+              <DialogDescription>
+                Selecciona carpeta, semana y materia para trabajar.
+              </DialogDescription>
+            </div>
           </DialogHeader>
           <div className="space-y-4">
             {folderName && (
@@ -1079,6 +1146,9 @@ audioLayer.ready.then((has) => {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Agregar Nuevo Nodo</DialogTitle>
+            <DialogDescription>
+              Ingresa el nombre del nodo y agrégalo al mapa.
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
@@ -1110,6 +1180,9 @@ audioLayer.ready.then((has) => {
                 ? `Mapas de ${SUBJECT_DATA[selectedSubject].name}`
                 : "Mapas"}
             </DialogTitle>
+            <DialogDescription>
+              Selecciona un mapa existente o crea uno nuevo.
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-2">
             {selectedWeek &&
@@ -1145,6 +1218,9 @@ audioLayer.ready.then((has) => {
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Temas del mapa</DialogTitle>
+            <DialogDescription>
+              Gestiona los temas del mapa y organiza los nodos.
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             {groups

--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -147,12 +147,10 @@ export class FileStore {
   async writeConfig<T = any>(cfg: T): Promise<void> {
     if (this.dirHandle) {
       const dataDir = await this.getDataDir();
-      const tmp = await dataDir.getFileHandle('config.tmp.json', { create: true });
-      const writable = await (tmp as any).createWritable();
+      const file = await dataDir.getFileHandle('config.json', { create: true });
+      const writable = await (file as any).createWritable();
       await writable.write(JSON.stringify(cfg));
       await writable.close();
-      await dataDir.removeEntry?.('config.json').catch(() => {});
-      await (tmp as any).move?.('config.json');
     } else {
       const db = await this.openDB();
       const tx = db.transaction('config', 'readwrite');
@@ -241,17 +239,15 @@ export class FileStore {
   async writeMeta(meta: MetadataFile): Promise<void> {
     if (this.dirHandle) {
       const dataDir = await this.getDataDir();
-        const tmp = await dataDir.getFileHandle('metadata.tmp.json', { create: true });
-        const writable = await (tmp as any).createWritable();
+      const file = await dataDir.getFileHandle('metadata.json', { create: true });
+      const writable = await (file as any).createWritable();
       await writable.write(JSON.stringify(meta));
       await writable.close();
-        await dataDir.removeEntry?.('metadata.json').catch(() => {});
-        await (tmp as any).move?.('metadata.json');
     } else {
       const db = await this.openDB();
-        const tx = db.transaction('metadata', 'readwrite');
-        tx.objectStore('metadata').put(meta, 'singleton');
-        await (tx as any).done?.catch(() => {});
+      const tx = db.transaction('metadata', 'readwrite');
+      tx.objectStore('metadata').put(meta, 'singleton');
+      await (tx as any).done?.catch(() => {});
     }
   }
 

--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -38,6 +38,7 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const startRecording = async (extId: string) => {
     try {
+      console.log('#graba');
       await recorder.start();
       updateState(extId, 'recording');
     } catch (e) {
@@ -47,7 +48,9 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const stopRecording = async (extId: string) => {
     try {
+      console.log('#corta grabacion');
       const blob = await recorder.stop();
+      console.log('#intentando guardar');
       await store.writeAudio(extId, blob, 'webm');
       const duration = await getDuration(blob);
       const now = new Date().toISOString();
@@ -61,7 +64,13 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
       };
       await saveMetadata();
       updateState(extId, 'has-audio');
+      const base = store.getDirName();
+      const path = base
+        ? `${base}/gestor/system/audios/${extId}.webm`
+        : `gestor/system/audios/${extId}.webm`;
+      console.log(`#guardado en ${path}`);
     } catch (e) {
+      updateState(extId, 'error');
       options?.onError?.('E_WRITE_FAIL', e);
     }
   };


### PR DESCRIPTION
## Summary
- ensure an "Ingresa nombre" node exists when maps are empty
- display emoji indicators for audio state and log recording/save steps
- add descriptions to all dialogs and write config/metadata directly to avoid locked file errors

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint must be installed: pnpm install --save-dev eslint)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ab9bf1eee48330821692d013a4d20d