### PR TITLE
Add default node and audio state emotes

### DIFF
--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -63,6 +63,7 @@ function DialogContent({
           "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           className
         )}
+        aria-describedby={undefined}
         {...props}
       >
         {children}

--- a/lib/audio/fileStore.ts
+++ b/lib/audio/fileStore.ts
@@ -147,12 +147,10 @@ export class FileStore {
   async writeConfig<T = any>(cfg: T): Promise<void> {
     if (this.dirHandle) {
       const dataDir = await this.getDataDir();
-      const tmp = await dataDir.getFileHandle('config.tmp.json', { create: true });
-      const writable = await (tmp as any).createWritable();
+      const file = await dataDir.getFileHandle('config.json', { create: true });
+      const writable = await (file as any).createWritable();
       await writable.write(JSON.stringify(cfg));
       await writable.close();
-      await dataDir.removeEntry?.('config.json').catch(() => {});
-      await (tmp as any).move?.('config.json');
     } else {
       const db = await this.openDB();
       const tx = db.transaction('config', 'readwrite');
@@ -241,17 +239,15 @@ export class FileStore {
   async writeMeta(meta: MetadataFile): Promise<void> {
     if (this.dirHandle) {
       const dataDir = await this.getDataDir();
-        const tmp = await dataDir.getFileHandle('metadata.tmp.json', { create: true });
-        const writable = await (tmp as any).createWritable();
+      const file = await dataDir.getFileHandle('metadata.json', { create: true });
+      const writable = await (file as any).createWritable();
       await writable.write(JSON.stringify(meta));
       await writable.close();
-        await dataDir.removeEntry?.('metadata.json').catch(() => {});
-        await (tmp as any).move?.('metadata.json');
     } else {
       const db = await this.openDB();
-        const tx = db.transaction('metadata', 'readwrite');
-        tx.objectStore('metadata').put(meta, 'singleton');
-        await (tx as any).done?.catch(() => {});
+      const tx = db.transaction('metadata', 'readwrite');
+      tx.objectStore('metadata').put(meta, 'singleton');
+      await (tx as any).done?.catch(() => {});
     }
   }
 

--- a/lib/audio/index.ts
+++ b/lib/audio/index.ts
@@ -38,6 +38,7 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const startRecording = async (extId: string) => {
     try {
+      console.log('#graba');
       await recorder.start();
       updateState(extId, 'recording');
     } catch (e) {
@@ -47,7 +48,9 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
 
   const stopRecording = async (extId: string) => {
     try {
+      console.log('#corta grabacion');
       const blob = await recorder.stop();
+      console.log('#intentando guardar');
       await store.writeAudio(extId, blob, 'webm');
       const duration = await getDuration(blob);
       const now = new Date().toISOString();
@@ -61,7 +64,13 @@ export function attachAudioLayer({ nodesSelection, getExtId, rootElement, option
       };
       await saveMetadata();
       updateState(extId, 'has-audio');
+      const base = store.getDirName();
+      const path = base
+        ? `${base}/gestor/system/audios/${extId}.webm`
+        : `gestor/system/audios/${extId}.webm`;
+      console.log(`#guardado en ${path}`);
     } catch (e) {
+      updateState(extId, 'error');
       options?.onError?.('E_WRITE_FAIL', e);
     }
   };


### PR DESCRIPTION
## Summary
- ensure an "Toca para grabar" node appears when maps are empty and starts recording immediately
- persist maps even when empty by filtering placeholder nodes
- write config/metadata directly to avoid locked move errors
- default dialog content `aria-describedby` to silence Radix warnings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint must be installed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab9bf1eee48330821692d013a4d20d