### PR TITLE
feat: adjust node spacing and size with keyboard

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,5 +1,7 @@
 export interface AppConfig {
   folderName?: string;
+  nodePadding?: number;
+  nodeSize?: number;
 }
 
 const KEY = 'appConfig';


### PR DESCRIPTION
## Summary
- allow changing node padding and size with g/c/m/n keys
- persist spacing and size settings across sessions

## Testing
- `pnpm build`
- `pnpm lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68adca17dfac8330b3ecc2763c03a53f